### PR TITLE
Add Jekyll cache and Bundler artifacts to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@ __pycache__/
 _site/
 vendor/
 
+.jekyll-cache/
+.bundle/


### PR DESCRIPTION
## Summary
- avoid committing Jekyll cache by ignoring `.jekyll-cache/`
- ignore Bundler artifacts via `.bundle/`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_683f8ab8d3f883258945a9fa674e5a0a