### PR TITLE
Add strategy post and updated home page

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,6 @@ url: "https://tu_usuario.github.io" # the base hostname & protocol for your site
 
 # Build settings
 markdown: kramdown
-theme: minima
+theme: jekyll-theme-minimal
 plugins:
   - jekyll-feed

--- a/_posts/2025-06-04-moving-average-crossover.md
+++ b/_posts/2025-06-04-moving-average-crossover.md
@@ -1,0 +1,20 @@
+---
+layout: post
+title: "Moving Average Crossover Strategy"
+date: 2025-06-04 00:00:00 +0000
+---
+
+Below is a minimal Python example illustrating a simple moving average crossover approach using daily SPY prices.
+
+```python
+import pandas as pd
+import yfinance as yf
+
+data = yf.download('SPY', start='2020-01-01', end='2020-12-31')
+data['fast_ma'] = data['Close'].rolling(window=20).mean()
+data['slow_ma'] = data['Close'].rolling(window=50).mean()
+signals = (data['fast_ma'] > data['slow_ma']).astype(int)
+print(signals.value_counts())
+```
+
+This generates a basic signal series where `1` represents times when the fast moving average is above the slow one.

--- a/index.md
+++ b/index.md
@@ -1,20 +1,31 @@
 ---
 layout: default
-title: Welcome
+title: Home
 ---
 
 <style>
-.welcome-container {
-  max-width: 600px;
+.home {
+  max-width: 650px;
   margin: 2rem auto;
-  padding: 1rem;
-  text-align: center;
   font-family: Arial, sans-serif;
+  line-height: 1.6;
+}
+.home h1 {
+  text-align: center;
 }
 </style>
 
-<div class="welcome-container">
+<div class="home">
   <h1>Welcome to the Trading Blog</h1>
-  <p>This site shares trading ideas and Python examples.</p>
-  <p>Check out the <a href="{{ '/2023/01/01/welcome.html' | relative_url }}">first post</a> to get started.</p>
+  <p>This site documents small trading experiments built with Python. The aim is to keep notes on simple strategies and share code snippets that can be expanded later.</p>
+
+  <h2>Recent Posts</h2>
+  <ul>
+    {% for post in site.posts limit:5 %}
+      <li><a href="{{ post.url | relative_url }}">{{ post.title }}</a> <small>{{ post.date | date: "%b %d, %Y" }}</small></li>
+    {% endfor %}
+  </ul>
+
+  <h2>About</h2>
+  <p>Notebooks used for exploration live in the <a href="{{ '/notebooks/' | relative_url }}">notebooks</a> folder. Posts summarise ideas such as the <a href="{{ '/2025/06/04/moving-average-crossover.html' | relative_url }}">moving average crossover strategy</a>.</p>
 </div>

--- a/notebooks/simple_trading_idea.md
+++ b/notebooks/simple_trading_idea.md
@@ -1,0 +1,14 @@
+# Simple Moving Average Crossover
+This example downloads daily prices for SPY and computes two moving averages. The crossover of the fast and slow averages is used as a trading signal.
+
+
+```python
+import pandas as pd
+import yfinance as yf
+
+data = yf.download('SPY', start='2020-01-01', end='2020-12-31')
+data['fast_ma'] = data['Close'].rolling(window=20).mean()
+data['slow_ma'] = data['Close'].rolling(window=50).mean()
+signals = (data['fast_ma'] > data['slow_ma']).astype(int)
+signals.value_counts()
+```


### PR DESCRIPTION
## Summary
- create a simple moving average strategy post
- update index with recent posts and about section
- export strategy notebook as Markdown

## Testing
- `bundle exec jekyll build`


------
https://chatgpt.com/codex/tasks/task_e_683f92c17998832599be6bb3091cbbd2