### PR TITLE
Fix publication date for trading blog post

### DIFF
--- a/_posts/2025-06-03-moving-average-crossover.md
+++ b/_posts/2025-06-03-moving-average-crossover.md
@@ -1,7 +1,7 @@
 ---
 layout: post
 title: "Moving Average Crossover Strategy"
-date: 2025-06-04 00:00:00 +0000
+date: 2025-06-03 00:00:00 +0000
 ---
 
 Below is a minimal Python example illustrating a simple moving average crossover approach using daily SPY prices.

--- a/index.md
+++ b/index.md
@@ -27,5 +27,5 @@ title: Home
   </ul>
 
   <h2>About</h2>
-  <p>Notebooks used for exploration live in the <a href="{{ '/notebooks/' | relative_url }}">notebooks</a> folder. Posts summarise ideas such as the <a href="{{ '/2025/06/04/moving-average-crossover.html' | relative_url }}">moving average crossover strategy</a>.</p>
+  <p>Notebooks used for exploration live in the <a href="{{ '/notebooks/' | relative_url }}">notebooks</a> folder. Posts summarise ideas such as the <a href="{{ '/2025/06/03/moving-average-crossover.html' | relative_url }}">moving average crossover strategy</a>.</p>
 </div>


### PR DESCRIPTION
## Summary
- update moving average post date to the current date
- fix link on index page

## Testing
- `bundle install --path vendor/bundle`
- `bundle exec jekyll build` *(fails: No repo name found)*

------
https://chatgpt.com/codex/tasks/task_e_683f9db918f48325be07b956b948f091