### PR TITLE
Add JupyterLite integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,3 +80,8 @@ bundle exec jekyll build
 ```
 
 The generated HTML will be available in the `_site/` directory and can be deployed to GitHub Pages.
+
+## Interactive Notebooks
+
+This site now loads a lightweight Python environment in the browser using thebe and JupyterLite. Posts such as the moving average crossover example include a **Run** button. Click it to execute code cells directly on the page. If network access is blocked, the notebook falls back to built-in sample data. When network access is available, packages like `yfinance` will fetch real market prices automatically.
+

--- a/_includes/head-custom.html
+++ b/_includes/head-custom.html
@@ -1,0 +1,12 @@
+<script type="text/x-thebe-config">
+{
+  requestKernel: true,
+  mountActivateWidget: true,
+  mountStatusWidget: true,
+  useJupyterLite: true
+}
+</script>
+<link rel="stylesheet" href="https://unpkg.com/thebe@0.9.3/lib/index.css">
+<script src="https://unpkg.com/thebe-lite@0.5.0/dist/lib/index.js"></script>
+<script src="https://unpkg.com/thebe@0.9.3/lib/index.js"></script>
+

--- a/_posts/2025-06-04-moving-average-crossover.md
+++ b/_posts/2025-06-04-moving-average-crossover.md
@@ -1,0 +1,42 @@
+---
+layout: post
+title: "Moving Average Crossover Strategy"
+date: 2025-06-04 00:00:00 +0000
+---
+
+<button id="run-notebook">Run</button>
+
+<pre data-executable="true" data-language="python">
+import pandas as pd
+try:
+    import yfinance as yf
+    data = yf.download('SPY', start='2020-01-01', end='2020-12-31')
+except Exception as e:
+    print('Using fallback data:', e)
+    csv = """Date,Close
+2020-01-01,320
+2020-02-01,330
+2020-03-01,280
+2020-04-01,290
+2020-05-01,300
+2020-06-01,310
+2020-07-01,320
+2020-08-01,330
+2020-09-01,340
+2020-10-01,350
+2020-11-01,360
+2020-12-01,370
+"""
+    from io import StringIO
+    data = pd.read_csv(StringIO(csv), parse_dates=['Date']).set_index('Date')
+
+data['fast_ma'] = data['Close'].rolling(3).mean()
+data['slow_ma'] = data['Close'].rolling(6).mean()
+ax = data[['fast_ma', 'slow_ma']].plot(title='SMA Crossover')
+</pre>
+<script>
+document.getElementById('run-notebook').addEventListener('click', function() {
+  thebe.bootstrap();
+});
+</script>
+

--- a/notebooks/sma_performance.ipynb
+++ b/notebooks/sma_performance.ipynb
@@ -1,0 +1,48 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# SMA Performance\n",
+    "This notebook fetches SPY data and plots a simple moving average crossover."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "metadata": {},
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd\n",
+    "import matplotlib.pyplot as plt\n",
+    "plt.rcParams['figure.dpi'] = 150\n",
+    "try:\n",
+    "    import yfinance as yf\n",
+    "    data = yf.download('SPY', start='2020-01-01', end='2020-12-31')\n",
+    "except Exception as e:\n",
+    "    print('Using fallback data:', e)\n",
+    "    csv = '''Date,Close\n2020-01-01,320\n2020-02-01,330\n2020-03-01,280\n2020-04-01,290\n2020-05-01,300\n2020-06-01,310\n2020-07-01,320\n2020-08-01,330\n2020-09-01,340\n2020-10-01,350\n2020-11-01,360\n2020-12-01,370'''\n",
+    "    from io import StringIO\n",
+    "    data = pd.read_csv(StringIO(csv), parse_dates=['Date']).set_index('Date')\n",
+    "data['fast_ma'] = data['Close'].rolling(3).mean()\n",
+    "data['slow_ma'] = data['Close'].rolling(6).mean()\n",
+    "ax = data[['fast_ma', 'slow_ma']].plot(title='SMA Crossover')\n",
+    "plt.show()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary
- embed thebe + JupyterLite assets in `head-custom.html`
- provide an interactive moving average post
- add a notebook with fallback data for offline runs
- document interactive notebooks in README

## Testing
- `bundle install`
- `PAGES_REPO_NWO=joelmrcdo/joelmrcdo.github.io bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_683fa0e30f6c832583054b261a01747d