### PR TITLE
Remove leftover merge markers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ The generated HTML will be available in the `_site/` directory and can be deploy
 
 This site now loads a lightweight Python environment in the browser using thebe and JupyterLite. Posts such as the moving average crossover example include a **Run** button. Click it to execute code cells directly on the page. If network access is blocked, the notebook falls back to built-in sample data. When network access is available, packages like `yfinance` will fetch real market prices automatically.
 
-=======
 ### Disclaimer
 This material is for educational purposes only and is not financial advice.
 

--- a/_posts/2025-06-04-moving-average-crossover.md
+++ b/_posts/2025-06-04-moving-average-crossover.md
@@ -41,7 +41,6 @@ document.getElementById('run-notebook').addEventListener('click', function() {
 });
 </script>
 
-=======
 Below is a minimal Python example illustrating a simple moving average crossover approach using daily SPY prices.
 
 ```python

--- a/index.md
+++ b/index.md
@@ -29,7 +29,6 @@ title: Home
   <h2>About</h2>
 
   <p>Notebooks used for exploration live in the <a href="{{ '/notebooks/' | relative_url }}">notebooks</a> folder. Posts summarise ideas such as the <a href="{{ '/2025/06/04/moving-average-crossover.html' | relative_url }}">moving average crossover strategy</a>.</p>
-=======
   <p>Notebooks used for exploration live in the <a href="{{ '/notebooks/' | relative_url }}">notebooks</a> folder. Posts summarise ideas such as the <a href="{{ '/2025/06/03/moving-average-crossover.html' | relative_url }}">moving average crossover strategy</a>.</p>
 
 </div>


### PR DESCRIPTION
## Summary
- delete stray merge markers from README
- remove leftover markers from index
- clean up merge marker in moving average post

## Testing
- `bundle exec jekyll build` *(fails: No repo name found)*

------
https://chatgpt.com/codex/tasks/task_e_683fa63e702c8325b90aa0ea171c875f