### PR TITLE
Add option calculator post

### DIFF
--- a/_posts/2025-07-01-option-target-calculator.md
+++ b/_posts/2025-07-01-option-target-calculator.md
@@ -1,0 +1,105 @@
+---
+layout: post
+title: "Option Price Target Calculator"
+date: 2025-07-01 00:00:00 +0000
+---
+
+<style>
+.calc-box {
+  max-width: 450px;
+  padding: 1em;
+  border: 1px solid #ddd;
+  background: #f9f9f9;
+}
+.calc-box label {
+  display: block;
+  margin-bottom: 0.5em;
+}
+.calc-box input,
+.calc-box select {
+  width: 100%;
+  padding: 0.3em;
+  margin-top: 0.2em;
+}
+.calc-box button {
+  margin-top: 0.5em;
+  padding: 0.4em 1em;
+}
+</style>
+
+<p>This calculator estimates the value of a plain vanilla option at a profit
+ target or stop level using the Black‑Scholes formula.</p>
+
+<div class="calc-box">
+  <label>Current underlying price
+    <input id="underlying" type="number" step="any" />
+  </label>
+  <label>Target price
+    <input id="target" type="number" step="any" />
+  </label>
+  <label>Stop price
+    <input id="stop" type="number" step="any" />
+  </label>
+  <label>Strike price
+    <input id="strike" type="number" step="any" />
+  </label>
+  <label>Days until expiry
+    <input id="days" type="number" step="any" />
+  </label>
+  <label>Implied volatility (%)
+    <input id="iv" type="number" step="any" />
+  </label>
+  <label>Risk‑free rate (%)
+    <input id="rate" type="number" step="any" value="5" />
+  </label>
+  <label>Option type
+    <select id="otype">
+      <option value="call">Call</option>
+      <option value="put">Put</option>
+    </select>
+  </label>
+  <button id="calc">Calculate</button>
+  <pre id="result"></pre>
+</div>
+
+<script>
+function normCdf(x) {
+  var t = 1 / (1 + 0.2316419 * Math.abs(x));
+  var d = 0.3989423 * Math.exp(-x * x / 2);
+  var prob = d * t * (0.3193815 + t * (-0.3565638 + t * (1.781478 + t * (-1.821256 + t * 1.330274))));
+  if (x >= 0) return 1 - prob; else return prob;
+}
+
+function blackScholes(S, K, T, r, sigma, type) {
+  var d1 = (Math.log(S / K) + (r + 0.5 * sigma * sigma) * T) / (sigma * Math.sqrt(T));
+  var d2 = d1 - sigma * Math.sqrt(T);
+  if (type === 'call') {
+    return S * normCdf(d1) - K * Math.exp(-r * T) * normCdf(d2);
+  } else {
+    return K * Math.exp(-r * T) * normCdf(-d2) - S * normCdf(-d1);
+  }
+}
+
+document.getElementById('calc').addEventListener('click', function() {
+  var S = parseFloat(document.getElementById('underlying').value);
+  var target = parseFloat(document.getElementById('target').value);
+  var stop = parseFloat(document.getElementById('stop').value);
+  var K = parseFloat(document.getElementById('strike').value);
+  var T = parseFloat(document.getElementById('days').value) / 365;
+  var sigma = parseFloat(document.getElementById('iv').value) / 100;
+  var r = parseFloat(document.getElementById('rate').value) / 100;
+  var type = document.getElementById('otype').value;
+
+  var current = blackScholes(S, K, T, r, sigma, type);
+  var targetVal = blackScholes(target, K, T, r, sigma, type);
+  var stopVal = blackScholes(stop, K, T, r, sigma, type);
+
+  document.getElementById('result').textContent =
+    'Current option price: ' + current.toFixed(2) + '\n' +
+    'Price at target: ' + targetVal.toFixed(2) + '\n' +
+    'Price at stop: ' + stopVal.toFixed(2);
+});
+</script>
+
+**Financial disclaimer:** This material is for educational purposes only and is not financial advice.
+


### PR DESCRIPTION
## Summary
- add an interactive option price target calculator post

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6841904e14ec8325a2928a5e2e40669a