### PR TITLE
Fix Thebe initialization in post

### DIFF
--- a/_posts/2025-06-04-moving-average-crossover.md
+++ b/_posts/2025-06-04-moving-average-crossover.md
@@ -136,7 +136,7 @@ stats_df = pd.Series({
 <script>
 document.getElementById('refresh-data').addEventListener('click', function() {
   thebe.bootstrap();
-  setTimeout(function(){ if (thebe) { thebe.runAll(); } }, 1000);
+  thebe.once('kernel_ready.Kernel', () => thebe.runAll());
 });
 </script>
 


### PR DESCRIPTION
## Summary
- trigger `thebe.runAll()` using the `kernel_ready.Kernel` event rather than a timeout in Moving Average Crossover post

## Testing
- `bundle check`
- `bundle exec jekyll build`

------
https://chatgpt.com/codex/tasks/task_e_6841ed676a6083258faf47f1f98ab442